### PR TITLE
Language patch pt-br for login.txt

### DIFF
--- a/inc/lang/pt-br/login.txt
+++ b/inc/lang/pt-br/login.txt
@@ -1,3 +1,3 @@
 ====== Autenticação ======
 
-Você não está autenticado. Digite as seus dados de usuário abaixo para entrar no sistema. É necessário habilitar os //cookies// no seu navegador para que isso funcione.
+Você não está autenticado. Digite os seus dados de usuário abaixo para entrar no sistema. É necessário habilitar os //cookies// no seu navegador para que isso funcione.


### PR DESCRIPTION
A little fix by changing to the correct word. Changing 'as' to 'os' in the text of login.txt